### PR TITLE
docs: fix mock setup instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you are using an instance of `PrismaClient` as a singleton, such as:
 // libs/client.ts
 import { PrismaClient } from "@prisma/client";
 
-export const prisma = new PrismaClient();
+export const client = new PrismaClient();
 ```
 
 ```ts
@@ -125,7 +125,7 @@ export default defineConfig({
 import { vi } from "vitest";
 
 vi.mock("./libs/client", () => ({
-  prisma: vPrisma.client,
+  client: vPrisma.client,
 }));
 ```
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ export default defineConfig({
 import { vi } from "vitest";
 
 vi.mock("./libs/client", () => ({
-  client: vPrisma.client,
+  prisma: vPrisma.client,
 }));
 ```
 


### PR DESCRIPTION
Since `libs/client.ts` exports `prisma`, a `vi.mock` should have `prisma` as a member instead of `client`, otherwise tests fail when running.