### PR TITLE
Remove "interactiveTransactions" preview feature from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,10 @@ export default defineConfig({
 }
 ```
 
-`vitest-environment-vprisma` uses [Prisma interactive transaction feature](https://www.prisma.io/docs/concepts/components/prisma-client/transactions#interactive-transactions-in-preview).
-
 ```prisma
 // schema.prisma
 generator client {
-  provider        = "prisma-client-js"
-  previewFeatures = ["interactiveTransactions"]
+  provider = "prisma-client-js"
 }
 ```
 


### PR DESCRIPTION
"interactiveTransactions" is no longer a preview feature in current versions of Prisma. The functionality can be used without specifying it as a preview feature.